### PR TITLE
feat: 회원가입 및 로그인 기능 구현

### DIFF
--- a/src/main/java/com/ioteam/auth/AuthController.java
+++ b/src/main/java/com/ioteam/auth/AuthController.java
@@ -1,0 +1,27 @@
+package com.ioteam.auth;
+
+import com.ioteam.auth.dto.AuthResponse;
+import com.ioteam.auth.dto.LoginRequest;
+import com.ioteam.auth.dto.SignupRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody SignupRequest request) {
+        userService.signup(request);
+        return ResponseEntity.ok("회원가입 완료");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(userService.login(request));
+    }
+}

--- a/src/main/java/com/ioteam/auth/UserService.java
+++ b/src/main/java/com/ioteam/auth/UserService.java
@@ -1,0 +1,62 @@
+package com.ioteam.auth;
+
+import com.ioteam.auth.dto.LoginRequest;
+import com.ioteam.auth.dto.SignupRequest;
+import com.ioteam.auth.dto.AuthResponse;
+import com.ioteam.domain.user.entity.User;
+import com.ioteam.domain.user.repository.UserRepository;
+import com.ioteam.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    public void signup(SignupRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+
+        User user = User.builder()
+            .name(request.getName())
+            .email(request.getEmail())
+            .password(passwordEncoder.encode(request.getPassword()))
+            .phone(request.getPhone())
+            .birthDate(request.getBirthDate())
+            .gender(User.Gender.valueOf(request.getGender().toUpperCase()))
+            .address(request.getAddress())
+            .profileImage(request.getProfileImage())
+            .role(User.Role.GUARDIAN)
+            .build();
+
+        userRepository.save(user);
+    }
+
+    public AuthResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtProvider.generateToken(user.getEmail());
+        String refreshToken = jwtProvider.generateToken(user.getEmail());
+
+        return new AuthResponse(
+            accessToken,
+            refreshToken,
+            user.getId(),
+            user.getName(),
+            user.getRole().name()
+        );
+    }
+}

--- a/src/main/java/com/ioteam/auth/dto/AuthResponse.java
+++ b/src/main/java/com/ioteam/auth/dto/AuthResponse.java
@@ -1,0 +1,14 @@
+package com.ioteam.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthResponse {
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String name;
+    private String role;
+}

--- a/src/main/java/com/ioteam/auth/dto/LoginRequest.java
+++ b/src/main/java/com/ioteam/auth/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.ioteam.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/ioteam/auth/dto/SignupRequest.java
+++ b/src/main/java/com/ioteam/auth/dto/SignupRequest.java
@@ -1,0 +1,19 @@
+package com.ioteam.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+    private String name;
+    private String email;
+    private String password;
+    private String phone;
+    private String birthDate;
+    private String gender;
+    private String address;
+    private String profileImage;
+}

--- a/src/main/java/com/ioteam/domain/user/UserController.java
+++ b/src/main/java/com/ioteam/domain/user/UserController.java
@@ -1,0 +1,25 @@
+package com.ioteam.domain.user;
+
+import com.ioteam.domain.user.entity.User;
+import com.ioteam.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('GUARDIAN')")
+    public ResponseEntity<UserInfoResponse> getMyInfo(Authentication auth) {
+        String email = auth.getName();
+        User user = userRepository.findByEmail(email).orElseThrow();
+        return ResponseEntity.ok(new UserInfoResponse(user));
+    }
+}

--- a/src/main/java/com/ioteam/domain/user/UserInfoResponse.java
+++ b/src/main/java/com/ioteam/domain/user/UserInfoResponse.java
@@ -1,0 +1,19 @@
+package com.ioteam.domain.user;
+
+import com.ioteam.domain.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserInfoResponse {
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final String role;
+
+    public UserInfoResponse(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.role = user.getRole().name();
+    }
+}


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가

### 반영 브랜치
feat/auth-api -> main

### 변경 사항
회원가입 api 구현
로그인 api 구현
jwt 발급 및 인증/인가 처리 완료
샘플 인증 테스트용 api 추가

### 테스트 결과
postman으로 회원가입/로그인 요청 테스트 완료 했습니다.
JWT 기반 인증 헤더를 포함한 요청에서 200 응답 확인 받았습니다.
잘못된 토큰 요청 시 403 응답 옵니다.

![호원가입](https://github.com/user-attachments/assets/ca424d57-3b5e-49ad-9dca-39ea70b9e2fc)
![화면 캡처 2025-05-21 032510](https://github.com/user-attachments/assets/31aa371a-443c-4d25-bda9-ec89611ddeb0)
![인증인가테스트](https://github.com/user-attachments/assets/92434b4d-2818-4d8b-a788-892d2bbc16ed)

