### PR TITLE
[Feat] 피보호자 등록 API 구현

### DIFF
--- a/src/main/java/com/ioteam/auth/UserService.java
+++ b/src/main/java/com/ioteam/auth/UserService.java
@@ -1,11 +1,16 @@
 package com.ioteam.auth;
 
 import com.ioteam.auth.dto.LoginRequest;
+import com.ioteam.auth.dto.SeniorRegisterRequest;
+import com.ioteam.auth.dto.SeniorRegisterResponse;
 import com.ioteam.auth.dto.SignupRequest;
 import com.ioteam.auth.dto.AuthResponse;
 import com.ioteam.domain.user.entity.User;
+import com.ioteam.domain.user.entity.User.Gender;
+import com.ioteam.domain.user.entity.User.Role;
 import com.ioteam.domain.user.repository.UserRepository;
 import com.ioteam.security.jwt.JwtProvider;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -59,4 +64,34 @@ public class UserService {
             user.getRole().name()
         );
     }
+    public SeniorRegisterResponse registerSenior(SeniorRegisterRequest request, Long guardianId) {
+        User guardian = userRepository.findById(guardianId)
+            .orElseThrow(() -> new UsernameNotFoundException("보호자를 찾을 수 없습니다."));
+
+        User senior = User.builder()
+            .name(request.getName())
+            .birthDate(LocalDate.parse(request.getBirthDate()))
+            .gender(Gender.valueOf(request.getGender()))
+            .address(request.getAddress())
+            .medicalHistory(request.getMedicalHistory())
+            .bloodType(request.getBloodType())
+            .profileImage(request.getProfileImage())
+            .role(Role.SENIOR)
+            .guardian(guardian)
+            .build();
+
+        userRepository.save(senior);
+
+        return new SeniorRegisterResponse(
+            senior.getId(),
+            senior.getName(),
+            senior.getBirthDate().toString(),
+            senior.getGender().name(),
+            senior.getAddress(),
+            senior.getMedicalHistory(),
+            senior.getBloodType(),
+            senior.getProfileImage()
+        );
+    }
+
 }

--- a/src/main/java/com/ioteam/auth/dto/SeniorRegisterRequest.java
+++ b/src/main/java/com/ioteam/auth/dto/SeniorRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.ioteam.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SeniorRegisterRequest {
+    private String name;
+    private String birthDate;
+    private String gender;
+    private String address;
+    private String medicalHistory;
+    private String bloodType;
+    private String profileImage;
+}

--- a/src/main/java/com/ioteam/auth/dto/SeniorRegisterResponse.java
+++ b/src/main/java/com/ioteam/auth/dto/SeniorRegisterResponse.java
@@ -1,0 +1,19 @@
+package com.ioteam.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SeniorRegisterResponse {
+    private Long id;
+    private String name;
+    private String birthDate;
+    private String gender;
+    private String address;
+    private String medicalHistory;
+    private String bloodType;
+    private String profileImage;
+}

--- a/src/main/java/com/ioteam/auth/dto/SignupRequest.java
+++ b/src/main/java/com/ioteam/auth/dto/SignupRequest.java
@@ -1,19 +1,39 @@
 package com.ioteam.auth.dto;
 
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class SignupRequest {
+
+    @NotBlank(message = "이름은 필수입니다.")
     private String name;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
     private String password;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호는 숫자 10~11자리여야 합니다.")
     private String phone;
-    private String birthDate;
+
+    @Past(message = "생년월일은 과거 날짜여야 합니다.")
+    private LocalDate birthDate;
+
+    @Pattern(regexp = "^(MALE|FEMALE|OTHER)$", message = "성별은 MALE 또는 FEMALE 여야 합니다.")
     private String gender;
+
     private String address;
+
     private String profileImage;
 }

--- a/src/main/java/com/ioteam/domain/user/UserController.java
+++ b/src/main/java/com/ioteam/domain/user/UserController.java
@@ -1,10 +1,15 @@
 package com.ioteam.domain.user;
 
+import com.ioteam.auth.UserService;
+import com.ioteam.auth.dto.SeniorRegisterRequest;
+import com.ioteam.auth.dto.SeniorRegisterResponse;
 import com.ioteam.domain.user.entity.User;
 import com.ioteam.domain.user.repository.UserRepository;
+import com.ioteam.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserRepository userRepository;
+    private final UserService userService;
 
     @GetMapping("/me")
     @PreAuthorize("hasRole('GUARDIAN')")
@@ -22,4 +28,15 @@ public class UserController {
         User user = userRepository.findByEmail(email).orElseThrow();
         return ResponseEntity.ok(new UserInfoResponse(user));
     }
+
+    @PostMapping("/register-senior")
+    @PreAuthorize("hasRole('GUARDIAN')")
+    public ResponseEntity<SeniorRegisterResponse> registerSenior(
+        @RequestBody SeniorRegisterRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        SeniorRegisterResponse response = userService.registerSenior(request, userDetails.getId());
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/ioteam/domain/user/entity/User.java
+++ b/src/main/java/com/ioteam/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.ioteam.domain.user.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -22,15 +23,15 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column()
     private String password;
 
     private String phone;
 
-    private String birthDate;
+    private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
@@ -39,6 +40,9 @@ public class User {
 
     private String profileImage;
 
+    private String medicalHistory;
+    private String bloodType;
+
     private String firebaseToken;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -46,7 +50,6 @@ public class User {
     private User guardian;
 
     private LocalDateTime createdAt;
-
     private LocalDateTime updatedAt;
 
     @PrePersist
@@ -70,4 +73,5 @@ public class User {
     public void encodePassword(PasswordEncoder encoder) {
         this.password = encoder.encode(this.password);
     }
+
 }

--- a/src/main/java/com/ioteam/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ioteam/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.ioteam.global.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+            errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException ex) {
+        return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+}

--- a/src/main/java/com/ioteam/security/config/SecurityConfig.java
+++ b/src/main/java/com/ioteam/security/config/SecurityConfig.java
@@ -44,13 +44,14 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/users/signup").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {

--- a/src/main/java/com/ioteam/security/service/CustomUserDetails.java
+++ b/src/main/java/com/ioteam/security/service/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package com.ioteam.security.service;
+
+import com.ioteam.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public Long getId() {
+        return user.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> "ROLE_" + user.getRole().name());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/ioteam/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ioteam/security/service/CustomUserDetailsService.java
@@ -18,10 +18,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
-        return org.springframework.security.core.userdetails.User.builder()
-            .username(user.getEmail())
-            .password(user.getPassword())
-            .roles(user.getRole().name())
-            .build();
+        return new CustomUserDetails(user);
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가


### 반영 브랜치
feat/register-senior -> main

### 변경 사항
피보호자 등록 API 구현

### 테스트 결과

postman으로 보호자가 로그인 후, 피보호자 등록 테스트 완료 했습니다.

보호자 로그인 후 accessToken 저장
![화면 캡처 2025-05-28 192654](https://github.com/user-attachments/assets/c9aa564b-cf18-4340-a5f9-b345fa4c6dcd)

여기에 accessToken 넣고 피보호자 등록
![화면 캡처 2025-05-28 195141](https://github.com/user-attachments/assets/3d86362e-7c3b-420e-b50c-4e628bafa9d9)

등록된 피보호자는 User 테이블에 role=SENIOR, guardian_id=보호자ID로 저장
![image](https://github.com/user-attachments/assets/0424c5f9-e70c-4408-a12d-6d8002bc156c)
