### PR TITLE
feat: 복약 일정 및 기록 CRUD API 구현

### DIFF
--- a/src/main/java/com/ioteam/domain/medication/MedicationController.java
+++ b/src/main/java/com/ioteam/domain/medication/MedicationController.java
@@ -1,0 +1,58 @@
+package com.ioteam.domain.medication;
+
+import com.ioteam.domain.medication.dto.*;
+import com.ioteam.security.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/medication")
+@RequiredArgsConstructor
+public class MedicationController {
+
+    private final MedicationService medicationService;
+
+    @PostMapping("/schedule")
+    public ResponseEntity<MedicationScheduleResponse> create(
+        @RequestBody MedicationScheduleRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(medicationService.createSchedule(request, userDetails.getId()));
+    }
+
+    @GetMapping("/schedule/{seniorId}")
+    public ResponseEntity<List<MedicationScheduleResponse>> getSchedules(@PathVariable Long seniorId) {
+        return ResponseEntity.ok(medicationService.getSchedulesBySenior(seniorId));
+    }
+
+    @PutMapping("/schedule/{scheduleId}")
+    public ResponseEntity<MedicationScheduleResponse> updateSchedule(
+        @PathVariable Long scheduleId,
+        @RequestBody MedicationScheduleRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(medicationService.updateSchedule(scheduleId, request, userDetails.getId()));
+    }
+
+    @DeleteMapping("/schedule/{scheduleId}")
+    public ResponseEntity<?> deleteSchedule(
+        @PathVariable Long scheduleId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        medicationService.deleteSchedule(scheduleId, userDetails.getId());
+        return ResponseEntity.ok("삭제 완료");
+    }
+
+    @PostMapping("/log")
+    public ResponseEntity<MedicationLogResponse> confirmMedication(
+        @RequestBody MedicationLogRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(medicationService.confirmMedication(request, userDetails.getId()));
+    }
+
+    @GetMapping("/log/{seniorId}")
+    public ResponseEntity<List<MedicationLogResponse>> getLogs(@PathVariable Long seniorId) {
+        return ResponseEntity.ok(medicationService.getLogsBySenior(seniorId));
+    }
+}

--- a/src/main/java/com/ioteam/domain/medication/MedicationService.java
+++ b/src/main/java/com/ioteam/domain/medication/MedicationService.java
@@ -1,0 +1,161 @@
+package com.ioteam.domain.medication;
+
+import com.ioteam.domain.medication.dto.*;
+import com.ioteam.domain.medication.entity.MedicationItem;
+import com.ioteam.domain.medication.entity.MedicationLog;
+import com.ioteam.domain.medication.entity.MedicationSchedule;
+import com.ioteam.domain.medication.repository.MedicationItemRepository;
+import com.ioteam.domain.medication.repository.MedicationLogRepository;
+import com.ioteam.domain.medication.repository.MedicationScheduleRepository;
+import com.ioteam.domain.user.entity.User;
+import com.ioteam.domain.user.repository.UserRepository;
+import com.ioteam.global.exception.EntityNotFoundException;
+import com.ioteam.global.exception.ForbiddenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MedicationService {
+
+    private final MedicationScheduleRepository scheduleRepository;
+    private final MedicationItemRepository itemRepository;
+    private final MedicationLogRepository logRepository;
+    private final UserRepository userRepository;
+
+    private User getUserOrThrow(Long id) {
+        return userRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다. (id=" + id + ")"));
+    }
+
+    private MedicationSchedule getScheduleOrThrow(Long id) {
+        return scheduleRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("복약 일정을 찾을 수 없습니다. (id=" + id + ")"));
+    }
+
+    private void checkGuardianPermission(MedicationSchedule schedule, Long guardianId) {
+        if (!schedule.getCreatedBy().getId().equals(guardianId)) {
+            throw new ForbiddenException("수정/삭제 권한이 없습니다.");
+        }
+    }
+
+    @Transactional
+    public MedicationScheduleResponse createSchedule(MedicationScheduleRequest request, Long guardianId) {
+        User senior = getUserOrThrow(request.getUserId());
+        User guardian = getUserOrThrow(guardianId);
+
+        MedicationSchedule schedule = MedicationSchedule.builder()
+            .user(senior)
+            .createdBy(guardian)
+            .time(request.getTime())
+            .build();
+
+        MedicationSchedule savedSchedule = scheduleRepository.save(schedule);
+
+        List<MedicationItem> items = request.getItems().stream()
+            .map(i -> MedicationItem.builder().schedule(savedSchedule).name(i.getName()).memo(i.getMemo()).build())
+            .collect(Collectors.toList());
+
+        itemRepository.saveAll(items);
+
+        return new MedicationScheduleResponse(
+            savedSchedule.getId(),
+            senior.getId(),
+            savedSchedule.getTime(),
+            items.stream().map(i -> new MedicationItemResponse(i.getId(), i.getName(), i.getMemo())).toList()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<MedicationScheduleResponse> getSchedulesBySenior(Long seniorId) {
+        List<MedicationSchedule> schedules = scheduleRepository.findByUserId(seniorId);
+        return schedules.stream().map(s -> new MedicationScheduleResponse(
+            s.getId(),
+            s.getUser().getId(),
+            s.getTime(),
+            s.getItems().stream().map(i -> new MedicationItemResponse(i.getId(), i.getName(), i.getMemo())).toList()
+        )).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public MedicationScheduleResponse updateSchedule(Long scheduleId, MedicationScheduleRequest request, Long guardianId) {
+        MedicationSchedule schedule = getScheduleOrThrow(scheduleId);
+        User guardian = getUserOrThrow(guardianId);
+        checkGuardianPermission(schedule, guardian.getId());
+
+        itemRepository.deleteAll(schedule.getItems());
+        List<MedicationItem> updatedItems = request.getItems().stream()
+            .map(i -> MedicationItem.builder()
+                .schedule(schedule)
+                .name(i.getName())
+                .memo(i.getMemo())
+                .build())
+            .collect(Collectors.toList());
+
+        schedule.getItems().clear();
+        schedule.getItems().addAll(updatedItems);
+        schedule.changeTime(request.getTime());
+        scheduleRepository.save(schedule);
+        itemRepository.saveAll(updatedItems);
+
+        MedicationSchedule updatedSchedule = getScheduleOrThrow(scheduleId);
+
+        return new MedicationScheduleResponse(
+            updatedSchedule.getId(),
+            updatedSchedule.getUser().getId(),
+            updatedSchedule.getTime(),
+            updatedSchedule.getItems().stream()
+                .map(i -> new MedicationItemResponse(i.getId(), i.getName(), i.getMemo()))
+                .toList()
+        );
+    }
+
+    @Transactional
+    public void deleteSchedule(Long scheduleId, Long guardianId) {
+        MedicationSchedule schedule = getScheduleOrThrow(scheduleId);
+        checkGuardianPermission(schedule, guardianId);
+        scheduleRepository.deleteById(scheduleId);
+    }
+
+    @Transactional
+    public MedicationLogResponse confirmMedication(MedicationLogRequest request, Long userId) {
+        MedicationSchedule schedule = getScheduleOrThrow(request.getScheduleId());
+        User user = getUserOrThrow(userId);
+
+        MedicationLog log = MedicationLog.builder()
+            .schedule(schedule)
+            .user(user)
+            .confirmedAt(request.getConfirmedAt())
+            .isNotified(false)
+            .build();
+
+        MedicationLog saved = logRepository.save(log);
+        return new MedicationLogResponse(
+            saved.getId(),
+            saved.getSchedule().getId(),
+            saved.getUser().getId(),
+            saved.getConfirmedAt(),
+            saved.isNotified(),
+            saved.getCreatedAt()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<MedicationLogResponse> getLogsBySenior(Long seniorId) {
+        List<MedicationLog> logs = logRepository.findByUserId(seniorId);
+        return logs.stream()
+            .map(log -> new MedicationLogResponse(
+                log.getId(),
+                log.getSchedule().getId(),
+                log.getUser().getId(),
+                log.getConfirmedAt(),
+                log.isNotified(),
+                log.getCreatedAt()
+            ))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ioteam/domain/medication/dto/MedicationItemRequest.java
+++ b/src/main/java/com/ioteam/domain/medication/dto/MedicationItemRequest.java
@@ -1,0 +1,9 @@
+package com.ioteam.domain.medication.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MedicationItemRequest {
+    private String name;
+    private String memo;
+}

--- a/src/main/java/com/ioteam/domain/medication/dto/MedicationItemResponse.java
+++ b/src/main/java/com/ioteam/domain/medication/dto/MedicationItemResponse.java
@@ -1,0 +1,12 @@
+package com.ioteam.domain.medication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MedicationItemResponse {
+    private Long id;
+    private String name;
+    private String memo;
+}

--- a/src/main/java/com/ioteam/domain/medication/dto/MedicationLogRequest.java
+++ b/src/main/java/com/ioteam/domain/medication/dto/MedicationLogRequest.java
@@ -1,0 +1,10 @@
+package com.ioteam.domain.medication.dto;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class MedicationLogRequest {
+    private Long scheduleId;
+    private LocalDateTime confirmedAt;
+}

--- a/src/main/java/com/ioteam/domain/medication/dto/MedicationLogResponse.java
+++ b/src/main/java/com/ioteam/domain/medication/dto/MedicationLogResponse.java
@@ -1,0 +1,16 @@
+package com.ioteam.domain.medication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MedicationLogResponse {
+    private Long logId;
+    private Long scheduleId;
+    private Long userId;
+    private LocalDateTime confirmedAt;
+    private boolean notified;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/ioteam/domain/medication/dto/MedicationScheduleRequest.java
+++ b/src/main/java/com/ioteam/domain/medication/dto/MedicationScheduleRequest.java
@@ -1,0 +1,12 @@
+package com.ioteam.domain.medication.dto;
+
+import lombok.Getter;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+public class MedicationScheduleRequest {
+    private Long userId;
+    private LocalTime time;
+    private List<MedicationItemRequest> items;
+}

--- a/src/main/java/com/ioteam/domain/medication/dto/MedicationScheduleResponse.java
+++ b/src/main/java/com/ioteam/domain/medication/dto/MedicationScheduleResponse.java
@@ -1,0 +1,15 @@
+package com.ioteam.domain.medication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MedicationScheduleResponse {
+    private Long scheduleId;
+    private Long userId;
+    private LocalTime time;
+    private List<MedicationItemResponse> items;
+}

--- a/src/main/java/com/ioteam/domain/medication/entity/MedicationItem.java
+++ b/src/main/java/com/ioteam/domain/medication/entity/MedicationItem.java
@@ -1,0 +1,37 @@
+package com.ioteam.domain.medication.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MedicationItem {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private MedicationSchedule schedule;
+
+    private String name;
+    private String memo;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ioteam/domain/medication/entity/MedicationLog.java
+++ b/src/main/java/com/ioteam/domain/medication/entity/MedicationLog.java
@@ -1,0 +1,35 @@
+package com.ioteam.domain.medication.entity;
+
+import com.ioteam.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MedicationLog {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private MedicationSchedule schedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDateTime confirmedAt;
+    private boolean isNotified;
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ioteam/domain/medication/entity/MedicationSchedule.java
+++ b/src/main/java/com/ioteam/domain/medication/entity/MedicationSchedule.java
@@ -1,0 +1,50 @@
+package com.ioteam.domain.medication.entity;
+
+import com.ioteam.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalTime;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MedicationSchedule {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalTime time;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MedicationItem> items;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changeTime(LocalTime time) {
+        this.time = time;
+    }
+}

--- a/src/main/java/com/ioteam/domain/medication/repository/MedicationItemRepository.java
+++ b/src/main/java/com/ioteam/domain/medication/repository/MedicationItemRepository.java
@@ -1,0 +1,7 @@
+package com.ioteam.domain.medication.repository;
+
+import com.ioteam.domain.medication.entity.MedicationItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MedicationItemRepository extends JpaRepository<MedicationItem, Long> {
+}

--- a/src/main/java/com/ioteam/domain/medication/repository/MedicationLogRepository.java
+++ b/src/main/java/com/ioteam/domain/medication/repository/MedicationLogRepository.java
@@ -1,0 +1,9 @@
+package com.ioteam.domain.medication.repository;
+
+import com.ioteam.domain.medication.entity.MedicationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface MedicationLogRepository extends JpaRepository<MedicationLog, Long> {
+    List<MedicationLog> findByUserId(Long userId);
+}

--- a/src/main/java/com/ioteam/domain/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ioteam/domain/medication/repository/MedicationScheduleRepository.java
@@ -1,0 +1,10 @@
+package com.ioteam.domain.medication.repository;
+
+import com.ioteam.domain.medication.entity.MedicationSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Long> {
+    List<MedicationSchedule> findByUserId(Long userId);
+}

--- a/src/main/java/com/ioteam/global/exception/EntityNotFoundException.java
+++ b/src/main/java/com/ioteam/global/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ioteam.global.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ioteam/global/exception/ForbiddenException.java
+++ b/src/main/java/com/ioteam/global/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.ioteam.global.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ioteam/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ioteam/global/exception/GlobalExceptionHandler.java
@@ -14,16 +14,24 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
-
         ex.getBindingResult().getFieldErrors().forEach(error ->
             errors.put(error.getField(), error.getDefaultMessage())
         );
-
         return ResponseEntity.badRequest().body(errors);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException ex) {
-        return ResponseEntity.badRequest().body(ex.getMessage());
+        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<?> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(404).body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<?> handleForbidden(ForbiddenException ex) {
+        return ResponseEntity.status(403).body(Map.of("error", ex.getMessage()));
     }
 }


### PR DESCRIPTION
### PR 타입
-[ x] 기능 추가

### 반영 브랜치
feat/medication-crud -> main

### 변경 사항
복약 일정 등록 API
복약 일정 조회 API
복약 일정 수정 API
복약 일정 삭제 API
복약 완료 기록 등록 API
복약 기록 조회 API

### 테스트 결과

postman 테스트 완료 했습니다.

복약 일정 등록
![post](https://github.com/user-attachments/assets/d509d736-c01e-4e84-8577-3d43fdd6fc5c)

복약 일정 조회
![get](https://github.com/user-attachments/assets/cab0d37c-bb80-4929-802e-eb1622f4b75e)

복약 일정 수정
![put](https://github.com/user-attachments/assets/a8f7fe8b-beb8-461e-ac80-0e067f538922)

복약 일정 삭제
![deletepng](https://github.com/user-attachments/assets/c2a3ff00-22ab-4019-a223-fff855c27068)

복약 완료 기록 등록 ( 로봇쪽에서 피보호자가 복약완료 버튼 클릭시 )
![log](https://github.com/user-attachments/assets/40baab33-0eca-48a8-9b63-e948b58bda9f)

복약 기록 조회 ( 보호자가 피보호자 id로 복약 기록 조회 )
![log조회](https://github.com/user-attachments/assets/4db6734f-02f5-4045-a604-201399fda3a9)
