### PR TITLE
feat: 낙상감지 CRU API 구현

### DIFF
--- a/src/main/java/com/ioteam/domain/careevent/CareEventController.java
+++ b/src/main/java/com/ioteam/domain/careevent/CareEventController.java
@@ -1,0 +1,47 @@
+package com.ioteam.domain.careevent;
+
+import com.ioteam.domain.careevent.dto.CareEventRequest;
+import com.ioteam.domain.careevent.dto.CareEventResponse;
+import com.ioteam.domain.user.entity.User;
+import com.ioteam.security.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CareEventController {
+
+    private final CareEventService careEventService;
+
+    @PostMapping("/care-events")
+    public ResponseEntity<CareEventResponse> create(@RequestBody CareEventRequest request) {
+        return ResponseEntity.ok(careEventService.createCareEvent(request));
+    }
+
+    @PreAuthorize("hasRole('GUARDIAN')")
+    @GetMapping("/guardians/me/care-events")
+    public ResponseEntity<List<CareEventResponse>> list(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        User guardian = userDetails.getUser();
+        return ResponseEntity.ok(careEventService.getEventsForGuardian(guardian));
+    }
+
+    @PreAuthorize("hasRole('GUARDIAN')")
+    @GetMapping("/care-events/{id}")
+    public ResponseEntity<CareEventResponse> get(@PathVariable Long id,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(careEventService.getEvent(id, userDetails.getUser()));
+    }
+
+    @PreAuthorize("hasRole('GUARDIAN')")
+    @PatchMapping("/care-events/{id}/ack")
+    public ResponseEntity<CareEventResponse> ack(@PathVariable Long id,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(careEventService.ackEvent(id, userDetails.getUser()));
+    }
+}

--- a/src/main/java/com/ioteam/domain/careevent/CareEventService.java
+++ b/src/main/java/com/ioteam/domain/careevent/CareEventService.java
@@ -1,0 +1,62 @@
+package com.ioteam.domain.careevent;
+
+import com.ioteam.domain.careevent.dto.CareEventRequest;
+import com.ioteam.domain.careevent.dto.CareEventResponse;
+import com.ioteam.domain.careevent.entity.CareEvent;
+import com.ioteam.domain.careevent.repository.CareEventRepository;
+import com.ioteam.domain.user.entity.User;
+import com.ioteam.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CareEventService {
+
+    private final CareEventRepository careEventRepository;
+    private final UserRepository userRepository;
+
+    public CareEventResponse createCareEvent(CareEventRequest request) {
+        User senior = userRepository.findById(request.getSeniorId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 피보호자를 찾을 수 없습니다."));
+
+        CareEvent event = CareEvent.builder()
+            .senior(senior)
+            .type(CareEvent.EventType.valueOf(request.getType()))
+            .status(CareEvent.Status.DETECTED)
+            .build();
+
+        careEventRepository.save(event);
+        return CareEventResponse.from(event);
+    }
+
+    public List<CareEventResponse> getEventsForGuardian(User guardian) {
+        List<User> seniors = userRepository.findByGuardianIdAndRole(guardian.getId(), User.Role.SENIOR);
+        return careEventRepository.findBySeniorIn(seniors)
+            .stream().map(CareEventResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    public CareEventResponse getEvent(Long id, User guardian) {
+        CareEvent event = careEventRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+        if (!event.getSenior().getGuardian().getId().equals(guardian.getId())) {
+            throw new SecurityException("이 이벤트에 접근할 권한이 없습니다.");
+        }
+        return CareEventResponse.from(event);
+    }
+
+    public CareEventResponse ackEvent(Long id, User guardian) {
+        CareEvent event = careEventRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+        if (!event.getSenior().getGuardian().getId().equals(guardian.getId())) {
+            throw new SecurityException("이 이벤트를 확인할 권한이 없습니다.");
+        }
+        event.ack();
+        careEventRepository.save(event);
+        return CareEventResponse.from(event);
+    }
+}

--- a/src/main/java/com/ioteam/domain/careevent/dto/CareEventRequest.java
+++ b/src/main/java/com/ioteam/domain/careevent/dto/CareEventRequest.java
@@ -1,0 +1,11 @@
+package com.ioteam.domain.careevent.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareEventRequest {
+    private Long seniorId;
+    private String type;
+}

--- a/src/main/java/com/ioteam/domain/careevent/dto/CareEventResponse.java
+++ b/src/main/java/com/ioteam/domain/careevent/dto/CareEventResponse.java
@@ -1,0 +1,29 @@
+package com.ioteam.domain.careevent.dto;
+
+import com.ioteam.domain.careevent.entity.CareEvent;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CareEventResponse {
+    private Long id;
+    private String type;
+    private String status;
+    private LocalDateTime occurredAt;
+    private Long seniorId;
+    private String seniorName;
+
+    public static CareEventResponse from(CareEvent event) {
+        return CareEventResponse.builder()
+            .id(event.getId())
+            .type(event.getType().name())
+            .status(event.getStatus().name())
+            .occurredAt(event.getOccurredAt())
+            .seniorId(event.getSenior().getId())
+            .seniorName(event.getSenior().getName())
+            .build();
+    }
+}

--- a/src/main/java/com/ioteam/domain/careevent/dto/FallVideoClipResponse.java
+++ b/src/main/java/com/ioteam/domain/careevent/dto/FallVideoClipResponse.java
@@ -1,0 +1,5 @@
+package com.ioteam.domain.careevent.dto;
+
+public class FallVideoClipResponse {
+
+}

--- a/src/main/java/com/ioteam/domain/careevent/entity/CareEvent.java
+++ b/src/main/java/com/ioteam/domain/careevent/entity/CareEvent.java
@@ -1,0 +1,49 @@
+package com.ioteam.domain.careevent.entity;
+
+import com.ioteam.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "care_event")
+public class CareEvent {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "senior_id", nullable = false)
+    private User senior;
+
+    @Enumerated(EnumType.STRING)
+    private EventType type;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private LocalDateTime occurredAt;
+
+    @PrePersist
+    protected void onCreate() {
+        occurredAt = LocalDateTime.now();
+        if (status == null) status = Status.DETECTED;
+    }
+
+    public enum EventType {
+        FALL, INTRUSION
+    }
+
+    public enum Status {
+        DETECTED, NOTIFIED, ACKED, RESOLVED
+    }
+
+    public void ack() {
+        this.status = Status.ACKED;
+    }
+}

--- a/src/main/java/com/ioteam/domain/careevent/entity/FallVideoClip.java
+++ b/src/main/java/com/ioteam/domain/careevent/entity/FallVideoClip.java
@@ -1,0 +1,5 @@
+package com.ioteam.domain.careevent.entity;
+
+public class FallVideoClip {
+
+}

--- a/src/main/java/com/ioteam/domain/careevent/repository/CareEventRepository.java
+++ b/src/main/java/com/ioteam/domain/careevent/repository/CareEventRepository.java
@@ -1,0 +1,11 @@
+package com.ioteam.domain.careevent.repository;
+
+import com.ioteam.domain.careevent.entity.CareEvent;
+import com.ioteam.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CareEventRepository extends JpaRepository<CareEvent, Long> {
+    List<CareEvent> findBySeniorIn(List<User> seniors);
+}

--- a/src/main/java/com/ioteam/domain/careevent/repository/FallVideoClipRepository.java
+++ b/src/main/java/com/ioteam/domain/careevent/repository/FallVideoClipRepository.java
@@ -1,0 +1,5 @@
+package com.ioteam.domain.careevent.repository;
+
+public class FallVideoClipRepository {
+
+}

--- a/src/main/java/com/ioteam/security/config/WebSocketConfig.java
+++ b/src/main/java/com/ioteam/security/config/WebSocketConfig.java
@@ -1,0 +1,5 @@
+package com.ioteam.security.config;
+
+public class WebSocketConfig {
+
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
feat/care-events -> main

### 변경 사항
CareEvent 엔티티 작성
CareEventRepository 작성
CareEventService, CareEventController 구현
(
낙상감지 이벤트 생성 구현
낙상감지 이벤트 목록 조회 구현
낙상감지 이벤트 상세 조회 구현
낙상감지 이벤트 확인 처리(보호자 전용) 구현
권한 처리 적용
)

### 테스트 결과
Postman으로 CRU API 호출 및 검증 완료

이벤트 생성 성공 ( status = DETECTED) 
<img width="637" height="626" alt="api-care-events(이벤트생성)" src="https://github.com/user-attachments/assets/e85c1a5a-be06-485c-88b2-4d1754264288" />

보호자 계정으로 이벤트 목록 조회 정상 동작
<img width="653" height="636" alt="이벤트조회" src="https://github.com/user-attachments/assets/b86237fa-241d-4f67-9543-4f2664dd941b" />

이벤트 상세 조회 정상 동작
<img width="667" height="627" alt="이벤트 상세조회" src="https://github.com/user-attachments/assets/287fb3fe-020d-47a2-93e3-1458d9aedf63" />

이벤트 ACK 처리시 status=ACKED 정상 변경
<img width="687" height="647" alt="보호자가 이벤트확인(ack처리)" src="https://github.com/user-attachments/assets/832573f0-b0b7-411c-b3b4-b7ff1fe2200b" />

