### PR TITLE
feat: 가족 얼굴 맞추기 게임 api 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:17-jdk-slim AS builder
+
+WORKDIR /workspace/app
+
+RUN apt-get update && apt-get install -y dos2unix \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY gradlew .
+RUN dos2unix gradlew
+RUN chmod +x gradlew
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+
+RUN ./gradlew build -x test
+
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+COPY --from=builder /workspace/app/build/libs/*.jar app.jar
+COPY --from=builder /workspace/app/src/main/resources/firebase-service-key.json .
+
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,10 @@ services:
     restart: always
     ports:
       - "13306:3306"
+    env_file:
+      - ./.env
     environment:
       TZ: Asia/Seoul
-      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
-      MARIADB_USER: ${MARIADB_USER}
-      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
-      MARIADB_DATABASE: ${MARIADB_DATABASE}
     volumes:
       - aro-mariadb-data:/var/lib/mysql
 
@@ -23,6 +21,22 @@ services:
       - "6379:6379"
     volumes:
       - aro-redis-data:/data
+
+  app:
+    build: .
+    container_name: aro-app
+    restart: always
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./.env
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mariadb://mariadb:3306/${MARIADB_DATABASE}?serverTimezone=Asia/Seoul
+    volumes:
+      - ./uploads:/app/uploads
+    depends_on:
+      - mariadb
+      - redis
 
 volumes:
   aro-mariadb-data:

--- a/src/main/java/com/ioteam/domain/game/GameController.java
+++ b/src/main/java/com/ioteam/domain/game/GameController.java
@@ -1,0 +1,51 @@
+package com.ioteam.domain.game;
+
+import com.ioteam.domain.game.dto.AnswerRequest;
+import com.ioteam.domain.game.dto.GameResultRequest;
+import com.ioteam.domain.game.dto.PhotoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class GameController {
+
+    private final GameService gameService;
+
+    @PostMapping("/photos")
+    public ResponseEntity<String> uploadPhoto(
+        @RequestPart("image") MultipartFile image,
+        @RequestPart("caption") String caption,
+        Authentication authentication) throws IOException {
+        gameService.uploadPhoto(authentication, image, caption);
+        return ResponseEntity.ok("사진이 성공적으로 업로드되었습니다.");
+    }
+
+    @GetMapping("/seniors/{seniorId}/photos")
+    public ResponseEntity<List<PhotoResponse>> getPhotosForGame(@PathVariable Long seniorId) {
+        List<PhotoResponse> photos = gameService.getPhotosForGame(seniorId);
+        return ResponseEntity.ok(photos);
+    }
+
+    @PostMapping("/photos/{photoId}/check-answer")
+    public ResponseEntity<Map<String, Boolean>> checkAnswer(
+        @PathVariable Long photoId,
+        @RequestBody AnswerRequest request) {
+        boolean isCorrect = gameService.checkAnswer(photoId, request.getAnswer());
+        return ResponseEntity.ok(Map.of("isCorrect", isCorrect));
+    }
+
+    @PostMapping("/game-results")
+    public ResponseEntity<String> saveGameResult(@RequestBody GameResultRequest request) {
+        gameService.saveGameResult(request);
+        return ResponseEntity.ok("게임 결과가 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/ioteam/domain/game/GameService.java
+++ b/src/main/java/com/ioteam/domain/game/GameService.java
@@ -1,0 +1,106 @@
+package com.ioteam.domain.game;
+
+import com.ioteam.domain.game.dto.GameResultRequest;
+import com.ioteam.domain.game.dto.PhotoResponse;
+import com.ioteam.domain.game.entity.GameResult;
+import com.ioteam.domain.game.entity.Photo;
+import com.ioteam.domain.game.repository.GameResultRepository;
+import com.ioteam.domain.game.repository.PhotoRepository;
+import com.ioteam.domain.user.entity.User;
+import com.ioteam.domain.user.repository.UserRepository;
+import com.ioteam.global.storage.FileUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GameService {
+    private final UserRepository userRepository;
+    private final PhotoRepository photoRepository;
+    private final GameResultRepository gameResultRepository;
+    private final FileUploadService fileUploadService;
+
+    private User getUserByAuth(Authentication authentication) {
+        return userRepository.findByEmail(authentication.getName())
+            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public void uploadPhoto(Authentication authentication, MultipartFile image, String caption) throws IOException {
+        User guardian = getUserByAuth(authentication);
+
+        String imageUrl = fileUploadService.upload(image, "photos");
+
+        if (imageUrl == null) {
+            throw new IOException("파일 업로드에 실패했습니다.");
+        }
+
+        Photo photo = Photo.builder()
+            .guardian(guardian)
+            .imageUrl(imageUrl)
+            .caption(caption)
+            .build();
+
+        photoRepository.save(photo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PhotoResponse> getPhotosForGame(Long seniorId) {
+        User senior = userRepository.findById(seniorId)
+            .orElseThrow(() -> new IllegalArgumentException("피보호자를 찾을 수 없습니다."));
+
+        User guardian = senior.getGuardian();
+        if (guardian == null) {
+            return Collections.emptyList();
+        }
+
+        List<Photo> photos = photoRepository.findAllByGuardian(guardian);
+        Collections.shuffle(photos);
+
+        return photos.stream()
+            .map(PhotoResponse::new)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkAnswer(Long photoId, String userAnswer) {
+        Photo photo = photoRepository.findById(photoId)
+            .orElseThrow(() -> new IllegalArgumentException("사진을 찾을 수 없습니다."));
+
+        if (userAnswer == null || userAnswer.trim().isEmpty()) {
+            return false;
+        }
+
+        String[] correctAnswers = photo.getCaption().split(",");
+        String cleanedUserAnswer = userAnswer.replaceAll("\\s+", "");
+
+        return Arrays.stream(correctAnswers)
+            .map(answer -> answer.trim().replaceAll("\\s+", ""))
+            .anyMatch(answer -> answer.equalsIgnoreCase(cleanedUserAnswer));
+    }
+
+    @Transactional
+    public void saveGameResult(GameResultRequest request) {
+        User senior = userRepository.findById(request.getSeniorId())
+            .orElseThrow(() -> new IllegalArgumentException("피보호자를 찾을 수 없습니다."));
+
+        GameResult result = GameResult.builder()
+            .senior(senior)
+            .gameType(request.getGameType())
+            .score(request.getScore())
+            .totalQuestions(request.getTotalQuestions())
+            .build();
+
+        gameResultRepository.save(result);
+    }
+}

--- a/src/main/java/com/ioteam/domain/game/dto/AnswerRequest.java
+++ b/src/main/java/com/ioteam/domain/game/dto/AnswerRequest.java
@@ -1,0 +1,10 @@
+package com.ioteam.domain.game.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AnswerRequest {
+    private String answer;
+}

--- a/src/main/java/com/ioteam/domain/game/dto/GameResultRequest.java
+++ b/src/main/java/com/ioteam/domain/game/dto/GameResultRequest.java
@@ -1,0 +1,14 @@
+package com.ioteam.domain.game.dto;
+
+import com.ioteam.domain.game.entity.GameResult;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GameResultRequest {
+    private Long seniorId;
+    private GameResult.GameType gameType;
+    private Integer score;
+    private Integer totalQuestions;
+}

--- a/src/main/java/com/ioteam/domain/game/dto/PhotoResponse.java
+++ b/src/main/java/com/ioteam/domain/game/dto/PhotoResponse.java
@@ -1,0 +1,17 @@
+package com.ioteam.domain.game.dto;
+
+import com.ioteam.domain.game.entity.Photo;
+import lombok.Getter;
+
+@Getter
+public class PhotoResponse {
+    private Long photoId;
+    private String imageUrl;
+    private String caption;
+
+    public PhotoResponse(Photo photo) {
+        this.photoId = photo.getId();
+        this.imageUrl = photo.getImageUrl();
+        this.caption = photo.getCaption();
+    }
+}

--- a/src/main/java/com/ioteam/domain/game/entity/GameResult.java
+++ b/src/main/java/com/ioteam/domain/game/entity/GameResult.java
@@ -1,0 +1,39 @@
+package com.ioteam.domain.game.entity;
+
+import com.ioteam.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GameResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "senior_id")
+    private User senior;
+
+    @Enumerated(EnumType.STRING)
+    private GameType gameType;
+
+    private Integer score;
+    private Integer totalQuestions;
+
+    private LocalDateTime playedAt;
+
+    public enum GameType {
+        FACE_MATCH
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        playedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ioteam/domain/game/entity/Photo.java
+++ b/src/main/java/com/ioteam/domain/game/entity/Photo.java
@@ -1,0 +1,35 @@
+package com.ioteam.domain.game.entity;
+
+import com.ioteam.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Photo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guardian_id")
+    private User guardian;
+
+    @Column(nullable = false, length = 512)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String caption;
+
+    private LocalDateTime uploadedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        uploadedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ioteam/domain/game/repository/GameResultRepository.java
+++ b/src/main/java/com/ioteam/domain/game/repository/GameResultRepository.java
@@ -1,0 +1,7 @@
+package com.ioteam.domain.game.repository;
+
+import com.ioteam.domain.game.entity.GameResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameResultRepository extends JpaRepository<GameResult, Long> {
+}

--- a/src/main/java/com/ioteam/domain/game/repository/PhotoRepository.java
+++ b/src/main/java/com/ioteam/domain/game/repository/PhotoRepository.java
@@ -1,0 +1,10 @@
+package com.ioteam.domain.game.repository;
+
+import com.ioteam.domain.game.entity.Photo;
+import com.ioteam.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> findAllByGuardian(User guardian);
+}

--- a/src/main/java/com/ioteam/global/storage/FileUploadService.java
+++ b/src/main/java/com/ioteam/global/storage/FileUploadService.java
@@ -1,0 +1,8 @@
+package com.ioteam.global.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+
+public interface FileUploadService {
+    String upload(MultipartFile file, String dirName) throws IOException;
+}

--- a/src/main/java/com/ioteam/global/storage/LocalFileUploadService.java
+++ b/src/main/java/com/ioteam/global/storage/LocalFileUploadService.java
@@ -1,0 +1,44 @@
+package com.ioteam.global.storage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class LocalFileUploadService implements FileUploadService {
+
+    @Value("${FILE_UPLOAD_DIR}")
+    private String uploadDirName;
+
+    @Override
+    public String upload(MultipartFile file, String dirName) throws IOException {
+        if (file.isEmpty()) {
+            return null;
+        }
+
+        String basePath = System.getProperty("user.dir");
+        String fullPath = basePath + File.separator + uploadDirName + dirName;
+
+        File uploadDir = new File(fullPath);
+        if (!uploadDir.exists()) {
+            uploadDir.mkdirs();
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        String savedFilename = uuid + extension;
+
+        String savedPath = fullPath + File.separator + savedFilename;
+        File savedFile = new File(savedPath);
+        file.transferTo(savedFile);
+
+        return "/" + uploadDirName + dirName + "/" + savedFilename;
+    }
+}

--- a/src/main/java/com/ioteam/security/config/FirebaseConfig.java
+++ b/src/main/java/com/ioteam/security/config/FirebaseConfig.java
@@ -14,8 +14,7 @@ public class FirebaseConfig {
 
     @PostConstruct
     public void init() throws IOException {
-        FileInputStream serviceAccount =
-            new FileInputStream("src/main/resources/firebase-service-key.json");
+        FileInputStream serviceAccount = new FileInputStream("/app/firebase-service-key.json");
 
         FirebaseOptions options = FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(serviceAccount))

--- a/src/main/java/com/ioteam/security/config/WebConfig.java
+++ b/src/main/java/com/ioteam/security/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.ioteam.security.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:./uploads/");
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
feat/family-game -> main

### 변경 사항
'가족 사진 맞추기' 인지 능력 향상 게임 기능 추가
DB 및 Entity ( Photo 테이블 및 JPA Entity 추가), ( GameResult 테이블 및 JPA Entity 추가)

파일 업로드 기능
( docker-compose.yml)에 volumes를 추가해 컨테이너 환경에서도 파일이 영구적으로 보존되도록 설정

API 구현
POST /api/photos: 보호자가 사진과 설명을 업로드하는 API

GET /api/seniors/{seniorId}/photos: 피보호자가 게임에 사용할 사진 목록을 조회하는 API

POST /api/photos/{photoId}/check-answer: 프론트엔드에서 변환한 텍스트 정답을 확인하는 API

POST /api/game-results: 게임의 최종 결과를 저장하는 API



### 테스트 결과

POST /api/photos: 보호자가 사진과 설명을 업로드하는 API
<img width="1190" height="538" alt="4번 사진 업로드성공01" src="https://github.com/user-attachments/assets/e6162b3c-b4ff-4895-94b8-9a9c048d50ab" />

폴더에 들어옴
<img width="456" height="92" alt="4번사진 업로드성공02png" src="https://github.com/user-attachments/assets/a9a65ef3-f25f-4e60-b40b-90732317ea8f" />

db에 들어옴
<img width="1072" height="180" alt="db사진" src="https://github.com/user-attachments/assets/71bcfb1d-2216-478b-90b8-9962a863f92c" />

GET /api/seniors/{seniorId}/photos: 피보호자가 게임에 사용할 사진 목록을 조회하는 API
<img width="996" height="553" alt="3번 조회" src="https://github.com/user-attachments/assets/9723f08f-7f54-434f-9ee7-d3f06e727f92" />

POST /api/photos/{photoId}/check-answer: 프론트엔드에서 변환한 텍스트 정답을 확인하는 API (정답)
<img width="992" height="530" alt="정답체크시 정답!" src="https://github.com/user-attachments/assets/f97fced2-0f43-4613-8bc2-234aaa703d33" />

// 오답
<img width="798" height="666" alt="정답체크시오답" src="https://github.com/user-attachments/assets/9fdfe62e-b8e7-4e75-847c-63459047b1f1" />

POST /api/game-results: 게임의 최종 결과를 저장하는 API
<img width="690" height="556" alt="게임결과저장" src="https://github.com/user-attachments/assets/d78b8538-b419-4706-9228-6f337d61bf3a" />

//db저장
<img width="812" height="217" alt="게임결과저장 db" src="https://github.com/user-attachments/assets/65ccd256-9cff-4f8a-94cd-ea1d623f817e" />


